### PR TITLE
Added: Allow user to edit their own property

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -36,6 +36,15 @@ class CreatePropertyForm(forms.Form):
 	availEnd = forms.DateTimeField(initial=datetime.now()+timedelta(weeks=20))
 	rooms = forms.IntegerField(initial=1)
 
+class EditPropertyForm(forms.Form):
+	title = forms.CharField(required=False)
+	description = forms.CharField(required=False)
+	address = forms.CharField(required=False)
+	country = forms.CharField(required=False)
+	city = forms.CharField(required=False)
+	postalCode = forms.CharField(required=False)
+	# image = forms.CharField(required=False)
+
 class SearchPropertyForm(forms.Form):
 	keyword = forms.CharField(required=False)
 	country = forms.CharField(required=False)

--- a/bidlet/urls.py
+++ b/bidlet/urls.py
@@ -16,7 +16,8 @@ from api.views import (
     createBid,
     createProperty,
     propertyDetails,
-    Listings
+    Listings,
+    property_edit_view
     )
 
 urlpatterns = [
@@ -27,6 +28,7 @@ urlpatterns = [
 	url(r'^listings/', Listings.as_view(), name='listings'),
 	url(r'^property/(?P<id>\d{1,})/$', propertyDetails.as_view(), name='property'),
     url(r'^property/create', createProperty, name="create-property"),
+    url(r'^property/(?P<propertyID>\d{1,})/edit', property_edit_view, name="edit-property"),
 
     # Budding Management
     url(r'^bid/(?P<propertyID>\d{1,})', createBid, name='create-bid'),

--- a/templates/property.html
+++ b/templates/property.html
@@ -18,6 +18,11 @@
     </div>
   {% endif %}
     <h1>Property Details</h1>
+
+    {% if user.is_authenticated and user.id == property.ownerID%}
+      <span><a href="/property/{{property.propertyID}}/edit">Edit</a> the property</span>
+    {% endif %}
+
     <h2>{{ property.title}}</h2>
     <div class="property">
       <div class="property__image">

--- a/templates/property/edit_property.html
+++ b/templates/property/edit_property.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block styles %}
+  <link rel="stylesheet" type="text/css" href="/static/property/listing.css" />
+{% endblock %}
+
+{% block content %}
+
+<div class="createProperty">
+  <h2>Edit Property</h2>
+  <form role="form" method="post">
+    {% csrf_token %} {{ propertyEditForm }}
+    <button type="submit">Submit</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
URL:
/property/{{id}}/edit

Added:

- User login required for sanity checks on create bid, create property, and edit property
- New edit property pages 
- Allows users to update some of the property page attr.
- More checks to make sure that users actually own the place before they can edit (on the front end and backend)
- Sends a message back to the template on success or fail

Screenshots:

Success view:
![image](https://cloud.githubusercontent.com/assets/22083509/24340151/1411a2be-127e-11e7-822b-ca29f93312ed.png)


Edit view:
![image](https://cloud.githubusercontent.com/assets/22083509/24340160/21fd6f34-127e-11e7-9352-45f61a7f023e.png)
